### PR TITLE
Defaulting data[b] to 0 means getData always returns something

### DIFF
--- a/examples/TemperatureAndHumidity/TemperatureAndHumidity.ino
+++ b/examples/TemperatureAndHumidity/TemperatureAndHumidity.ino
@@ -19,18 +19,24 @@ void setup() {
 
 void loop() {
 
+  String str = ""
+  
   if (dht.getData()) {                         // get All data from DHT11
     float tempDeg = dht.getTemperature();      // return temperature in celsius
     float tempFar = dht.getTemperature(true);  // return temperature in fahrenheit if true celsius of false
     int hum = dht.getHumidity();               // return humidity
-    String str  = "Temperature: ";
-           str += tempDeg;
-           str += "°C  ";
-           str += tempFar;
-           str += "°F  Humidity:";
-           str += hum;
+    str += "Temperature: ";
+    str += tempDeg;
+    str += "°C  ";
+    str += tempFar;
+    str += "°F  Humidity:";
+    str += hum;
     Serial.println(str.c_str());
     //Serial.printf("Temperature: %0.1lf°C  %0.1lf°F Humidity:%d \n", tempDeg, tempFar, hum);
-  }
+  } else {
+    str += "No response from sensor!"
+  };
+  Serial.println(str.c_str());
+
   delay(2000);  //delay atleast 2 seconds for DHT11 to read tha data
 }

--- a/examples/TemperatureAndHumidity/TemperatureAndHumidity.ino
+++ b/examples/TemperatureAndHumidity/TemperatureAndHumidity.ino
@@ -9,7 +9,7 @@
 
 #include <Bonezegei_DHT11.h>
 
-//param = DHT11 signal pin
+//param = DHT11 signal pin (Digital)
 Bonezegei_DHT11 dht(14);
 
 void setup() {
@@ -19,12 +19,21 @@ void setup() {
 
 void loop() {
 
+  float humAdjust = 0.85;  //DHT11 & DHT22 are known to be "off" - use this to adjust to your experience
+  float tempAdjust = 1.0;  //This is less-known to be off but included in case you want to use it.
+  
   String str = ""
   
   if (dht.getData()) {                         // get All data from DHT11
     float tempDeg = dht.getTemperature();      // return temperature in celsius
     float tempFar = dht.getTemperature(true);  // return temperature in fahrenheit if true celsius of false
     int hum = dht.getHumidity();               // return humidity
+
+    //Apply Adjustments
+    tempDeg *= tempAdjust;
+    tempFar *= tempAdjust;
+    hum *= humAdjust;
+    
     str += "Temperature: ";
     str += tempDeg;
     str += "°C  ";

--- a/src/Bonezegei_DHT11.cpp
+++ b/src/Bonezegei_DHT11.cpp
@@ -26,7 +26,10 @@ char Bonezegei_DHT11::begin() {
 }
 
 char Bonezegei_DHT11::getData() {
-  data[0] = data[1] = data[2] = data[3] = data[4] = 0;
+  for (int b = 0; b < 5; b++) {
+    data[b] = b;
+  };
+
   digitalWrite(_pin, HIGH);
   delay(250);
 


### PR DESCRIPTION
I really liked the if(getData()) in the example code's loop but since data[0] through data[4] were all zeroes, the comparison with date[5] always said that they matched.

I was able to pull the DHT11 module out of my circuit entirely and was still told that it is 32°F and 0 humidity - in Florida in August - because the current code is defaulting to 0s. 